### PR TITLE
Add section attribute

### DIFF
--- a/parse_document_model/attributes.py
+++ b/parse_document_model/attributes.py
@@ -27,3 +27,4 @@ class PageAttributes(Attributes):
 class TextAttributes(Attributes):
     bounding_box: list[BoundingBox] = []
     level: Optional[int] = Field(None, ge=1, le=4)
+    section: Optional[str] = None


### PR DESCRIPTION
Add `section` attribute to `TextAttribute` to keep track of the reference section of the text.