### PR TITLE
Make marks hashable and comparable

### DIFF
--- a/parse_document_model/marks.py
+++ b/parse_document_model/marks.py
@@ -10,15 +10,34 @@ class Color(BaseModel):
     g: int
     b: int
 
+    def __eq__(self, other: Any) -> bool:
+        return (isinstance(other, Color) and
+                self.id == other.id and
+                self.r == other.r and
+                self.g == other.g and
+                self.b == other.b)
+
+    def __hash__(self) -> int:
+        return hash((self.id, self.r, self.g, self.b))
+
 
 class Font(BaseModel):
     id: str
     name: str
     size: int
 
+    def __eq__(self, other: Any) -> bool:
+        return (isinstance(other, Font) and
+                self.id == other.id and
+                self.size == other.size and
+                self.name == other.name)
+
+    def __hash__(self) -> int:
+        return hash((self.id, self.size, self.name))
+
 
 class Mark(BaseModel):
-    category: Literal['bold', 'italic', 'textStyle', 'link']
+    category: Literal['bold', 'italic', 'superscripted', 'serifed', 'monospaced', 'textStyle', 'link']
 
     @model_validator(mode='before')
     def check_details(self: Any) -> Any:
@@ -37,11 +56,34 @@ class Mark(BaseModel):
                 raise ValueError('textStyle should not be provided when type is link')
         return self
 
+    def __eq__(self, other):
+        return isinstance(other, Mark) and self.category == other.category
+
+    def __hash__(self) -> int:
+        return hash(self.category)
+
 
 class TextStyleMark(Mark):
     color: Optional[Color] = None
     font: Optional[Font] = None
 
+    def __eq__(self, other):
+        return (isinstance(other, TextStyleMark) and
+                self.category == other.category and
+                self.color == other.color and
+                self.font == other.font)
+
+    def __hash__(self) -> int:
+        return hash((self.category, self.color, self.font))
+
 
 class UrlMark(Mark):
     url: str
+
+    def __eq__(self, other):
+        return (isinstance(other, UrlMark) and
+                self.category == other.category and
+                self.url == other.url)
+
+    def __hash__(self) -> int:
+        return hash((self.category, self.url))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(ROOT, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='parse-document-model',
-    version='0.2.1',
+    version='0.2.2',
     description='Pydantic models for representing a text document as a hierarchical structure.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add implementation of `__eq__` and `__hash__` to the marks classes. Bump version to 0.2.2